### PR TITLE
zeptocore: add debounce to timestretch to prevent crashing when sequencing

### DIFF
--- a/lib/zeptocore.h
+++ b/lib/zeptocore.h
@@ -130,6 +130,7 @@ void input_handling() {
   }
 
   uint8_t debounce_beat_repeat = 0;
+  uint16_t debounce_sel_variation_next = 0;
 
   // debug test
   printStringWithDelay("zv2.7.2");
@@ -631,7 +632,10 @@ void input_handling() {
 #endif
 
     // load the new sample if variation changed
-    if (sel_variation_next != sel_variation) {
+    if (debounce_sel_variation_next > 0) {
+      debounce_sel_variation_next--;
+    } else if (sel_variation_next != sel_variation) {
+      debounce_sel_variation_next = 50;
       if (!audio_callback_in_mute) {
         while (!sync_using_sdcard) {
           sleep_us(250);


### PR DESCRIPTION
Fixes #384