### PR TITLE
rp2350 fixes for buttons and double timing

### DIFF
--- a/lib/buttonmatrix3.h
+++ b/lib/buttonmatrix3.h
@@ -92,6 +92,8 @@ ButtonMatrix *ButtonMatrix_create(uint base_input, uint base_output) {
   uint offset = pio_add_program(bm->pio, &button_matrix_program);
   pio_sm_config c = button_matrix_program_get_default_config(offset);
   sm_config_set_in_pins(&c, base_input);
+  sm_config_set_clkdiv(&c,256);
+
   pio_sm_set_consecutive_pindirs(bm->pio, bm->sm, base_output,
                                  BUTTONMATRIX_COLS, true);
   sm_config_set_set_pins(&c, base_output, BUTTONMATRIX_COLS);

--- a/main.c
+++ b/main.c
@@ -754,7 +754,7 @@ int main() {
   // it again 500ms later regardless of how long the callback took to execute
   // add_repeating_timer_ms(-1000, repeating_timer_callback, NULL, &timer);
   // cancel_repeating_timer(&timer);
-  update_repeating_timer_to_bpm(sf->bpm_tempo);
+ 
   // initialize random library
   random_initialize();
 
@@ -806,6 +806,7 @@ int main() {
 
   // printf("startup!\n");
   sdcard_startup();
+  update_repeating_timer_to_bpm(sf->bpm_tempo); // has to come after sdcard_startup()
 
   // TODO
   // load chain from SD card


### PR DESCRIPTION
Add clockdiv to button PIO just in case

Move `update_repeating_timer_to_bpm` to after `sdcard_startup` to fix the sequencer bpm not being zero at startup