### PR TITLE
Fix for Bass note off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ drum_separation_model_output/
 ectocore-default/
 soxstatic/
 
+zeptocore.uf2
+pico-examples

--- a/lib/button_handler.h
+++ b/lib/button_handler.h
@@ -880,6 +880,11 @@ bool button_handler(ButtonMatrix *bm) {
       // send out midi notes
       MidiOut_off(midiout[mode_buttons16], bm->off[i] - 4);
 #endif
+#ifdef INCLUDE_SINEBASS
+        if (mode_buttons16 == MODE_BASS) {
+          WaveBass_release(wavebass);
+        }
+#endif
     }
   }
 


### PR DESCRIPTION
Fix for issue #750

adds `WaveBass_release(wavebass);` in the same place as the `MidiOut_off`