### PR TITLE
apply ectocore clock mult/div to actual clock not just output

### DIFF
--- a/main.c
+++ b/main.c
@@ -74,10 +74,19 @@ bool __not_in_flash_func(timer_step)() {
 
   bpm_timer_counter++;
 
+#ifdef INCLUDE_ECTOCORE
+  bool do_splice_trigger = (bpm_timer_counter % (banks[sel_bank_cur]
+                                                     ->sample[sel_sample_cur]
+                                                     .snd[FILEZERO]
+                                                     ->splice_trigger *
+                                                 ectocore_clock_out_divisions[ectocore_clock_selected_division] /
+                                                 8)) == 0;
+#else
   bool do_splice_trigger = (bpm_timer_counter % (banks[sel_bank_cur]
                                                      ->sample[sel_sample_cur]
                                                      .snd[FILEZERO]
                                                      ->splice_trigger)) == 0;
+#endif
 
 // ectocore clocking
 #ifdef INCLUDE_ECTOCORE


### PR DESCRIPTION
not sure if this is something you'd want to do, but i almost exclusively use Ectocore with an external clock, and this feels like a fairly straightforward way of adjusting the relative clock speed

(warning: i have very little idea what i'm doing)