### PR TITLE
Add MIDI CC variables and CC input handler

### DIFF
--- a/lib/globals.h
+++ b/lib/globals.h
@@ -152,21 +152,21 @@ bool midi_input_activated = false;
 #endif
 
  // setup some constants for CCs
-const uint8_t cc_knobx = 0;
-const uint8_t cc_knoby= 1;
-const uint8_t cc_knobz = 2;
-const uint8_t cc_tempo = 3;
-const uint8_t cc_pitch = 4;
-const uint8_t cc_volume = 5;
-const uint8_t cc_randsequence = 6;
-const uint8_t cc_djfilter = 7;
-const uint8_t cc_bassvolume = 8;
-const uint8_t cc_sampleselect = 9;
-const uint8_t cc_randtunnel = 10;
-const uint8_t cc_quantize = 11;
-const uint8_t cc_randjump = 12;
-const uint8_t cc_randfx = 13;
-const uint8_t cc_randfxbank = 14;
+const uint8_t cc_knobx = 12;
+const uint8_t cc_knoby= 13;
+const uint8_t cc_knobz = 14;
+const uint8_t cc_tempo = 15;
+const uint8_t cc_pitch = 16;
+const uint8_t cc_volume = 7;
+const uint8_t cc_randsequence = 18;
+const uint8_t cc_djfilter = 19;
+const uint8_t cc_bassvolume = 20;
+const uint8_t cc_sampleselect = 21;
+const uint8_t cc_randtunnel = 22;
+const uint8_t cc_quantize = 23;
+const uint8_t cc_randjump = 24;
+const uint8_t cc_randfx = 25;
+const uint8_t cc_randfxbank = 26;
 
 bool toggle_chain_play = false;
 bool toggle_chain_rec = false;


### PR DESCRIPTION
* add MIDI CC variables to globals
* adds CC input handler
* changes arcade knob CC values to match output from combos

Changes to allow for remote control of knob/combos from any MIDI controller. I've built example controllers in Max and TouchOSC - which we could add to the repo somewhere if wanted.

I do have a minor concern that the CC map is controllers 0-14 - as some of these are "dedicated" controls like Bank Select* or ModWheel - or that CC 7 is usually Volume, but volume is CC 5 on zeptocore.

Can these mappings change?

\* I'd like to add a bank/patch select via MIDI and this would usually be CC 0 + CC 32